### PR TITLE
Support COSE serialization

### DIFF
--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/ByteStringWrapper.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/ByteStringWrapper.kt
@@ -1,0 +1,67 @@
+package kotlinx.serialization.cbor
+
+/**
+ * Use this class if you'll need to serialize a complex type as a byte string before encoding it,
+ * i.e. as it is the case with the protected header in COSE structures.
+ *
+ * Clients also need to write a custom serializer, i.e. in the form of
+ *
+ * ```
+ * @Serializable
+ * data class CoseHeader(
+ *     @SerialLabel(1)
+ *     @SerialName("alg")
+ *     val alg: Int? = null
+ * )
+ *
+ * @Serializable
+ * data class CoseSigned(
+ *     @Serializable(with = ByteStringWrapperSerializer::class)
+ *     @ByteString
+ *     @SerialLabel(1)
+ *     @SerialName("protectedHeader")
+ *     val protectedHeader: ByteStringWrapper<CoseHeader>,
+ * )
+ *
+ * object ByteStringWrapperSerializer : KSerializer<ByteStringWrapper<CoseHeader>> {
+ *     override val descriptor: SerialDescriptor =
+ *         PrimitiveSerialDescriptor("ByteStringWrapperSerializer", PrimitiveKind.STRING)
+ *     override fun serialize(encoder: Encoder, value: ByteStringWrapper<CoseHeader>) {
+ *         val bytes = Cbor.encodeToByteArray(value.value)
+ *         encoder.encodeSerializableValue(ByteArraySerializer(), bytes)
+ *     }
+ *     override fun deserialize(decoder: Decoder): ByteStringWrapper<CoseHeader> {
+ *         val bytes = decoder.decodeSerializableValue(ByteArraySerializer())
+ *         return ByteStringWrapper(Cbor.decodeFromByteArray(bytes), bytes)
+ *     }
+ * }
+ * ```
+ *
+ * then serializing a `CoseSigned` object would result in `a10143a10126`, in diagnostic notation:
+ *
+ * ```
+ * A1           # map(1)
+ *    01        # unsigned(1)
+ *    43        # bytes(3)
+ *       A10126 # "\xA1\u0001&"
+ * ```
+ *
+ * so the `protectedHeader` got serialized first and then encoded as a `@ByteString`
+ */
+public data class ByteStringWrapper<T>(
+    val value: T,
+    val serialized: ByteArray = byteArrayOf()
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ByteStringWrapper<*>
+
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value?.hashCode() ?: 0
+    }
+}

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -30,6 +30,8 @@ import kotlinx.serialization.modules.*
  *                      [KeyTags] annotation during the deserialization process. Useful for lenient parsing
  * @param verifyValueTags Specifies whether tags preceding values should be matched against the [ValueTags]
  *                      annotation during the deserialization process. Useful for lenient parsing.
+ * @param alwaysUseByteString Specifies whether to always use the compact [ByteString] encoding when serializing
+ *                            or deserializing byte arrays.
  * @param preferSerialLabelsOverNames Specifies whether to serialize element labels (i.e. Long from [SerialLabel])
  *                                    instead of the element names (i.e. String from [SerialName]) for map keys
  */
@@ -42,6 +44,7 @@ public sealed class Cbor(
     internal val verifyKeyTags: Boolean,
     internal val verifyValueTags: Boolean,
     internal val preferSerialLabelsOverNames: Boolean,
+    internal val alwaysUseByteString: Boolean,
     override val serializersModule: SerializersModule
 ) : BinaryFormat {
 
@@ -54,9 +57,10 @@ public sealed class Cbor(
      * - does verify key tags (see [verifyKeyTags])
      * - does verify value tags (see [verifyValueTags])
      * - does prefer serial labels over names (see [preferSerialLabelsOverNames])
+     * - does not use [ByteString] encoding (see [alwaysUseByteString])
      * - has an empty serializers module (see [EmptySerializersModule])
      */
-    public companion object Default : Cbor(false, false, true, true, true, true, true, EmptySerializersModule())
+    public companion object Default : Cbor(false, false, true, true, true, true, true, false, EmptySerializersModule())
 
     override fun <T> encodeToByteArray(serializer: SerializationStrategy<T>, value: T): ByteArray {
         val output = ByteArrayOutput()
@@ -80,6 +84,7 @@ private class CborImpl(
     verifyKeyTags: Boolean,
     verifyValueTags: Boolean,
     preferSerialLabelsOverNames: Boolean,
+    alwaysUseByteString: Boolean,
     serializersModule: SerializersModule
 ) :
     Cbor(
@@ -90,6 +95,7 @@ private class CborImpl(
         verifyKeyTags,
         verifyValueTags,
         preferSerialLabelsOverNames,
+        alwaysUseByteString,
         serializersModule
     )
 
@@ -109,6 +115,7 @@ public fun Cbor(from: Cbor = Cbor, builderAction: CborBuilder.() -> Unit): Cbor 
         builder.verifyKeyTags,
         builder.verifyValueTags,
         builder.preferSerialLabelsOverNames,
+        builder.alwaysUseByteString,
         builder.serializersModule
     )
 }
@@ -155,6 +162,11 @@ public class CborBuilder internal constructor(cbor: Cbor) {
      * Specifies whether to serialize element labels (i.e. Long from [SerialLabel]) instead of the element names (i.e. String from [SerialName]) for map keys
      */
     public var preferSerialLabelsOverNames: Boolean = cbor.preferSerialLabelsOverNames
+
+    /**
+     * Specifies whether to always use the compact [ByteString] encoding when serializing or deserializing byte arrays.
+     */
+    public var alwaysUseByteString: Boolean = cbor.alwaysUseByteString
 
     /**
      * Module with contextual and polymorphic serializers to be used in the resulting [Cbor] instance.

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -30,6 +30,8 @@ import kotlinx.serialization.modules.*
  *                      [KeyTags] annotation during the deserialization process. Useful for lenient parsing
  * @param verifyValueTags Specifies whether tags preceding values should be matched against the [ValueTags]
  *                      annotation during the deserialization process. Useful for lenient parsing.
+ * @param preferSerialLabelsOverNames Specifies whether to serialize element labels (i.e. Long from [SerialLabel])
+ *                                    instead of the element names (i.e. String from [SerialName]) for map keys
  */
 @ExperimentalSerializationApi
 public sealed class Cbor(
@@ -39,13 +41,14 @@ public sealed class Cbor(
     internal val writeValueTags: Boolean,
     internal val verifyKeyTags: Boolean,
     internal val verifyValueTags: Boolean,
+    internal val preferSerialLabelsOverNames: Boolean,
     override val serializersModule: SerializersModule
 ) : BinaryFormat {
 
     /**
      * The default instance of [Cbor]
      */
-    public companion object Default : Cbor(false, false, true, true, true, true, EmptySerializersModule())
+    public companion object Default : Cbor(false, false, true, true, true, true, true, EmptySerializersModule())
 
     override fun <T> encodeToByteArray(serializer: SerializationStrategy<T>, value: T): ByteArray {
         val output = ByteArrayOutput()
@@ -68,6 +71,7 @@ private class CborImpl(
     writeValueTags: Boolean,
     verifyKeyTags: Boolean,
     verifyValueTags: Boolean,
+    preferSerialLabelsOverNames: Boolean,
     serializersModule: SerializersModule
 ) :
     Cbor(
@@ -77,6 +81,7 @@ private class CborImpl(
         writeValueTags,
         verifyKeyTags,
         verifyValueTags,
+        preferSerialLabelsOverNames,
         serializersModule
     )
 
@@ -95,6 +100,7 @@ public fun Cbor(from: Cbor = Cbor, builderAction: CborBuilder.() -> Unit): Cbor 
         builder.writeValueTags,
         builder.verifyKeyTags,
         builder.verifyValueTags,
+        builder.preferSerialLabelsOverNames,
         builder.serializersModule
     )
 }
@@ -136,6 +142,11 @@ public class CborBuilder internal constructor(cbor: Cbor) {
      * Specifies whether tags preceding values should be matched against the [ValueTags] annotation during the deserialization process
      */
     public var verifyValueTags: Boolean = cbor.verifyValueTags
+
+    /**
+     * Specifies whether to serialize element labels (i.e. Long from [SerialLabel]) instead of the element names (i.e. String from [SerialName]) for map keys
+     */
+    public var preferSerialLabelsOverNames: Boolean = cbor.preferSerialLabelsOverNames
 
     /**
      * Module with contextual and polymorphic serializers to be used in the resulting [Cbor] instance.

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/Cbor.kt
@@ -46,7 +46,15 @@ public sealed class Cbor(
 ) : BinaryFormat {
 
     /**
-     * The default instance of [Cbor]
+     * The default instance of [Cbor], with the following behavior. It ...
+     * - does not encode defaults (see [encodeDefaults])
+     * - does not ignore unknown keys (see [ignoreUnknownKeys])
+     * - does write key tags (see [writeKeyTags])
+     * - does write value tags (see [writeValueTags])
+     * - does verify key tags (see [verifyKeyTags])
+     * - does verify value tags (see [verifyValueTags])
+     * - does prefer serial labels over names (see [preferSerialLabelsOverNames])
+     * - has an empty serializers module (see [EmptySerializersModule])
      */
     public companion object Default : Cbor(false, false, true, true, true, true, true, EmptySerializersModule())
 

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborArray.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/CborArray.kt
@@ -1,0 +1,8 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+
+@SerialInfo
+@Target(AnnotationTarget.CLASS)
+@ExperimentalSerializationApi
+public annotation class CborArray(@OptIn(ExperimentalUnsignedTypes::class) vararg val tag: ULong)

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/SerialLabel.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/SerialLabel.kt
@@ -1,0 +1,8 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+@ExperimentalSerializationApi
+public annotation class SerialLabel(val label: Long)

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -327,15 +327,14 @@ internal open class CborReader(private val cbor: Cbor, protected val decoder: Cb
     }
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
-
         val index = if (cbor.ignoreUnknownKeys) {
             val knownIndex: Int
             while (true) {
                 if (isDone()) return CompositeDecoder.DECODE_DONE
-                val (elemName, tags) = decoder.nextTaggedString()
+                val (elemName, tags) = decodeElementNameWithTagsLenient(descriptor)
                 readProperties++
 
-                val index = descriptor.getElementIndex(elemName)
+                val index = elemName?.let { descriptor.getElementIndex(it) } ?: CompositeDecoder.UNKNOWN_NAME
                 if (index == CompositeDecoder.UNKNOWN_NAME) {
                     decoder.skipElement(tags)
                 } else {
@@ -351,14 +350,7 @@ internal open class CborReader(private val cbor: Cbor, protected val decoder: Cb
             knownIndex
         } else {
             if (isDone()) return CompositeDecoder.DECODE_DONE
-            val (elemName, tags) = runCatching {
-                decoder.nextTaggedString()
-            }.getOrElse {
-                val serialLabel = decoder.nextNumber(null)
-                val elemName = descriptor.getElementNameForSerialLabel(serialLabel)
-                    ?: throw CborDecodingException("SerialLabel unknown: $serialLabel")
-                elemName to ulongArrayOf() // TODO Tags?
-            }
+            val (elemName, tags) = decodeElementNameWithTags(descriptor)
             readProperties++
             descriptor.getElementIndexOrThrow(elemName).also { index ->
                 if (cbor.verifyKeyTags) {
@@ -372,6 +364,26 @@ internal open class CborReader(private val cbor: Cbor, protected val decoder: Cb
         decodeByteArrayAsByteString = descriptor.isByteString(index)
         tags = if (cbor.verifyValueTags) descriptor.getValueTags(index) else null
         return index
+    }
+
+    private fun decodeElementNameWithTags(descriptor: SerialDescriptor): Pair<String, ULongArray?> {
+        var (elemName, serialLabel, tags) = decoder.nextTaggedStringOrNumber()
+        if (elemName == null && serialLabel != null) {
+            elemName = descriptor.getElementNameForSerialLabel(serialLabel)
+                ?: throw CborDecodingException("SerialLabel unknown: $serialLabel")
+        }
+        if (elemName == null) {
+            throw CborDecodingException("Expected (tagged) string or number, got nothing")
+        }
+        return elemName to tags
+    }
+
+    private fun decodeElementNameWithTagsLenient(descriptor: SerialDescriptor): Pair<String?, ULongArray?> {
+        var (elemName, serialLabel, tags) = decoder.nextTaggedStringOrNumber()
+        if (elemName == null && serialLabel != null) {
+            elemName = descriptor.getElementNameForSerialLabel(serialLabel)
+        }
+        return elemName to tags
     }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -541,12 +553,37 @@ internal class CborDecoder(private val input: ByteArrayInput) {
         }
     }
 
+    /**
+     * Used for reading the tags and either string (element name) or number (serial label)
+     */
+    fun nextTaggedStringOrNumber(): Triple<String?, Long?, ULongArray?> {
+        val collectedTags = processTags(null)
+        if ((curByte and 0b111_00000) == HEADER_STRING.toInt()) {
+            val arr = readBytes()
+            val ans = arr.decodeToString()
+            readByte()
+            return Triple(ans, null, collectedTags)
+        } else {
+            val res = readNumber()
+            readByte()
+            return Triple(null, res, collectedTags)
+        }
+    }
+
     fun nextNumber(tag: ULong): Long = nextNumber(ulongArrayOf(tag))
     fun nextNumber(tags: ULongArray? = null): Long {
         processTags(tags)
         val res = readNumber()
         readByte()
         return res
+    }
+    fun nextTaggedNumber() = nextTaggedNumber(null)
+
+    private fun nextTaggedNumber(tags: ULongArray?): Pair<Long, ULongArray?> {
+        val collectedTags = processTags(tags)
+        val res = readNumber()
+        readByte()
+        return res to collectedTags
     }
 
     private fun readNumber(): Long {

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -95,7 +95,8 @@ internal open class CborWriter(private val cbor: Cbor, protected val encoder: Cb
 
     @OptIn(ExperimentalSerializationApi::class)
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
-        if (encodeByteArrayAsByteString && serializer.descriptor == ByteArraySerializer().descriptor) {
+        if ((encodeByteArrayAsByteString || cbor.alwaysUseByteString)
+            && serializer.descriptor == ByteArraySerializer().descriptor) {
             encoder.encodeByteString(value as ByteArray)
         } else {
             super.encodeSerializableValue(serializer, value)
@@ -388,8 +389,8 @@ internal open class CborReader(private val cbor: Cbor, protected val decoder: Cb
 
     @OptIn(ExperimentalSerializationApi::class)
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
-
-        return if (decodeByteArrayAsByteString && deserializer.descriptor == ByteArraySerializer().descriptor) {
+        return if ((decodeByteArrayAsByteString || cbor.alwaysUseByteString)
+            && deserializer.descriptor == ByteArraySerializer().descriptor) {
             @Suppress("UNCHECKED_CAST")
             decoder.nextByteString(tags) as T
         } else {

--- a/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
+++ b/formats/cbor/commonMain/src/kotlinx/serialization/cbor/internal/Encoding.kt
@@ -103,11 +103,12 @@ internal open class CborWriter(private val cbor: Cbor, protected val encoder: Cb
             }
         }
 
-        val name = descriptor.getElementName(index)
-        descriptor.getSerialLabel(index)?.let {
-            encoder.encodeNumber(it)
-        } ?: {
-            encoder.encodeString(name)
+        val serialName = descriptor.getElementName(index)
+        val serialLabel = descriptor.getSerialLabel(index)
+        if (cbor.preferSerialLabelsOverNames && serialLabel != null) {
+            encoder.encodeNumber(serialLabel)
+        } else {
+            encoder.encodeString(serialName)
         }
 
         if (cbor.writeValueTags) {

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborArrayTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborArrayTest.kt
@@ -26,7 +26,7 @@ class CborArrayTest {
     private val reference2HexString = "c8822663666f6f"
 
     /**
-     * BF                 # map(*)
+     * A1                 # map(1)
      *    65              # text(5)
      *       6172726179   # "array"
      *    C8              # tag(8)
@@ -34,9 +34,8 @@ class CborArrayTest {
      *          26        # negative(6)
      *          63        # text(3)
      *             626172 # "bar"
-     *    FF              # primitive(*)
      */
-    private val reference3HexString = "bf656172726179c8822663626172ff"
+    private val reference3HexString = "a1656172726179c8822663626172"
 
     @Test
     fun writeReadVerifyArraySize1() {

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborArrayTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborArrayTest.kt
@@ -1,0 +1,84 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+
+class CborArrayTest {
+
+    private val reference1 = ClassAs1Array(alg = -7)
+    private val reference2 = ClassAs2Array(alg = -7, kid = "foo")
+    private val reference3 = ClassWithArray(array = ClassAs2Array(alg = -7, kid = "bar"))
+
+    /**
+     * 81    # array(1)
+     *    26 # negative(6)
+     */
+    private val reference1HexString = "8126"
+
+    /**
+     * C8              # tag(8)
+     *    82           # array(2)
+     *       26        # negative(6)
+     *       63        # text(3)
+     *          666F6F # "foo"
+     */
+    private val reference2HexString = "c8822663666f6f"
+
+    /**
+     * BF                 # map(*)
+     *    65              # text(5)
+     *       6172726179   # "array"
+     *    C8              # tag(8)
+     *       82           # array(2)
+     *          26        # negative(6)
+     *          63        # text(3)
+     *             626172 # "bar"
+     *    FF              # primitive(*)
+     */
+    private val reference3HexString = "bf656172726179c8822663626172ff"
+
+    @Test
+    fun writeReadVerifyArraySize1() {
+        val cbor = Cbor
+        assertEquals(reference1HexString, cbor.encodeToHexString(ClassAs1Array.serializer(), reference1))
+        assertEquals(reference1, cbor.decodeFromHexString(ClassAs1Array.serializer(), reference1HexString))
+    }
+
+    @Test
+    fun writeReadVerifyArraySize2() {
+        val cbor = Cbor
+        assertEquals(reference2HexString, cbor.encodeToHexString(ClassAs2Array.serializer(), reference2))
+        assertEquals(reference2, cbor.decodeFromHexString(ClassAs2Array.serializer(), reference2HexString))
+    }
+
+    @Test
+    fun writeReadVerifyClassWithArray() {
+        val cbor = Cbor
+        assertEquals(reference3HexString, cbor.encodeToHexString(ClassWithArray.serializer(), reference3))
+        assertEquals(reference3, cbor.decodeFromHexString(ClassWithArray.serializer(), reference3HexString))
+    }
+
+    @CborArray
+    @Serializable
+    data class ClassAs1Array(
+        @SerialName("alg")
+        val alg: Int,
+    )
+
+    @CborArray(8U)
+    @Serializable
+    data class ClassAs2Array(
+        @SerialName("alg")
+        val alg: Int,
+        @SerialName("kid")
+        val kid: String,
+    )
+
+    @Serializable
+    data class ClassWithArray(
+        @SerialName("array")
+        val array: ClassAs2Array,
+    )
+}
+

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborByteStringWrapperTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborByteStringWrapperTest.kt
@@ -11,13 +11,12 @@ class CborByteStringWrapperTest {
     private val reference = CoseSigned(protectedHeader = ByteStringWrapper(CoseHeader(alg = -7)))
 
     /**
-     * BF             # map(*)
-     *    01          # unsigned(1)
-     *    44          # bytes(4)
-     *       BF0126FF # "\xBF\u0001&\xFF"
-     *    FF          # primitive(*)
+     * A1           # map(1)
+     *    01        # unsigned(1)
+     *    43        # bytes(3)
+     *       A10126 # "\xA1\u0001&"
      */
-    private val referenceHex = "bf0144bf0126ffff"
+    private val referenceHex = "a10143a10126"
 
     @Test
     fun writeReadVerifyCoseSigned() {

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborByteStringWrapperTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborByteStringWrapperTest.kt
@@ -1,0 +1,62 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlin.test.*
+
+class CborByteStringWrapperTest {
+
+    private val reference = CoseSigned(protectedHeader = ByteStringWrapper(CoseHeader(alg = -7)))
+
+    /**
+     * BF             # map(*)
+     *    01          # unsigned(1)
+     *    44          # bytes(4)
+     *       BF0126FF # "\xBF\u0001&\xFF"
+     *    FF          # primitive(*)
+     */
+    private val referenceHex = "bf0144bf0126ffff"
+
+    @Test
+    fun writeReadVerifyCoseSigned() {
+        assertEquals(referenceHex, Cbor.encodeToHexString(CoseSigned.serializer(), reference))
+        assertEquals(reference, Cbor.decodeFromHexString(referenceHex))
+    }
+
+
+    @Serializable
+    data class CoseHeader(
+        @SerialLabel(1)
+        @SerialName("alg")
+        val alg: Int? = null
+    )
+
+    @Serializable
+    data class CoseSigned(
+        @Serializable(with = ByteStringWrapperSerializer::class)
+        @ByteString
+        @SerialLabel(1)
+        @SerialName("protectedHeader")
+        val protectedHeader: ByteStringWrapper<CoseHeader>,
+    )
+
+    object ByteStringWrapperSerializer : KSerializer<ByteStringWrapper<CoseHeader>> {
+
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("ByteStringWrapperSerializer", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: ByteStringWrapper<CoseHeader>) {
+            val bytes = Cbor.encodeToByteArray(value.value)
+            encoder.encodeSerializableValue(ByteArraySerializer(), bytes)
+        }
+
+        override fun deserialize(decoder: Decoder): ByteStringWrapper<CoseHeader> {
+            val bytes = decoder.decodeSerializableValue(ByteArraySerializer())
+            return ByteStringWrapper(Cbor.decodeFromByteArray(bytes), bytes)
+        }
+
+    }
+
+}

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborClassDefiniteMapTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborClassDefiniteMapTest.kt
@@ -1,0 +1,124 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlin.test.*
+
+class CborClassDefiniteMapTest {
+
+    private val reference1 = ClassWith1Member("foo")
+    private val reference2 = ClassWith2Member("foo", "bar")
+    private val reference3 = ClassWith3Member("foo", "bar", "baz")
+    private val referenceNullable = ClassWithNullableMembers(member3 = "foo")
+
+    /**
+     * A1                   # map(1)
+     *    67                # text(7)
+     *       6D656D62657231 # "member1"
+     *    63                # text(3)
+     *       666F6F         # "foo"
+     */
+    private val reference1Hex = "a1676d656d6265723163666f6f"
+
+    /**
+     * A2                   # map(2)
+     *    67                # text(7)
+     *       6D656D62657231 # "member1"
+     *    63                # text(3)
+     *       666F6F         # "foo"
+     *    67                # text(7)
+     *       6D656D62657232 # "member2"
+     *    63                # text(3)
+     *       626172         # "bar"
+     *
+     */
+    private val reference2Hex = "a2676d656d6265723163666f6f676d656d6265723263626172"
+
+    /**
+     * A3                   # map(3)
+     *    67                # text(7)
+     *       6D656D62657231 # "member1"
+     *    63                # text(3)
+     *       666F6F         # "foo"
+     *    67                # text(7)
+     *       6D656D62657232 # "member2"
+     *    63                # text(3)
+     *       626172         # "bar"
+     *    67                # text(7)
+     *       6D656D62657233 # "member3"
+     *    63                # text(3)
+     *       62617A         # "baz"
+     *
+     */
+    private val reference3Hex = "a3676d656d6265723163666f6f676d656d6265723263626172676d656d626572336362617a"
+
+    /**
+     * A1                   # map(1)
+     *    67                # text(7)
+     *       6D656D62657233 # "member3"
+     *    63                # text(3)
+     *       666F6F         # "foo"
+     */
+    private val referenceNullableHex = "a1676d656d6265723363666f6f"
+
+    @Test
+    fun writeReadVerifyReference1() {
+        assertEquals(reference1Hex, Cbor.encodeToHexString(ClassWith1Member.serializer(), reference1))
+        assertEquals(reference1, Cbor.decodeFromHexString(reference1Hex))
+    }
+
+    @Test
+    fun writeReadVerifyReference2() {
+        assertEquals(reference2Hex, Cbor.encodeToHexString(ClassWith2Member.serializer(), reference2))
+        assertEquals(reference2, Cbor.decodeFromHexString(reference2Hex))
+    }
+
+    @Test
+    fun writeReadVerifyReference3() {
+        assertEquals(reference3Hex, Cbor.encodeToHexString(ClassWith3Member.serializer(), reference3))
+        assertEquals(reference3, Cbor.decodeFromHexString(reference3Hex))
+    }
+
+    @Test
+    fun writeReadVerifyNullable() {
+        assertEquals(referenceNullableHex, Cbor.encodeToHexString(ClassWithNullableMembers.serializer(), referenceNullable))
+        assertEquals(referenceNullable, Cbor.decodeFromHexString(referenceNullableHex))
+    }
+
+    @Serializable
+    data class ClassWith1Member(
+        @SerialName("member1")
+        val member1: String,
+    )
+
+    @Serializable
+    data class ClassWith2Member(
+        @SerialName("member1")
+        val member1: String,
+        @SerialName("member2")
+        val member2: String,
+    )
+
+    @Serializable
+    data class ClassWith3Member(
+        @SerialName("member1")
+        val member1: String,
+        @SerialName("member2")
+        val member2: String,
+        @SerialName("member3")
+        val member3: String,
+    )
+
+    @Serializable
+    data class ClassWithNullableMembers(
+        @SerialName("member1")
+        val member1: String? = null,
+        @SerialName("member2")
+        val member2: String? = null,
+        @SerialName("member3")
+        val member3: String,
+    )
+
+}

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborCoseTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborCoseTest.kt
@@ -1,0 +1,112 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlin.test.*
+
+class CborCoseTest {
+
+    private val reference = CoseSigned(
+        protectedHeader = ByteStringWrapper(CoseHeader(alg = -7)),
+        unprotectedHeader = CoseHeader(kid = "11"),
+        payload = "This is the content.".encodeToByteArray(),
+        signature = HexConverter.parseHexBinary("8EB33E4CA31D1C465AB05AAC34CC6B23D58FEF5C083106C4D25A91AEF0B0117E2AF9A291AA32E14AB834DC56ED2A223444547E01F11D3B0916E5A4C345CACB36")
+    )
+
+    /**
+     * D2                                      # tag(18)
+     *    84                                   # array(4)
+     *       43                                # bytes(3)
+     *          A10126                         # "\xA1\u0001&" (serialized map(1) unsigned(1) negative(6))
+     *       A1                                # map(1)
+     *          04                             # unsigned(4)
+     *          42                             # bytes(2)
+     *             3131                        # "11"
+     *       54                                # bytes(20)
+     *          546869732069732074686520636F6E74656E742E # "This is the content."
+     *       58 40                             # bytes(64)
+     *          8EB33E4CA31D1C465AB05AAC34CC6B23D58FEF5C083106C4D25A91AEF0B0117E2AF9A291AA32E14AB834DC56ED2A223444547E01F11D3B0916E5A4C345CACB36
+     *
+     *
+     * OR
+     *
+     *
+     * 18([h'A10126', {4: h'3131'}, h'546869732069732074686520636F6E74656E742E', h'8EB33E4CA31D1C465AB05AAC34CC6B23D58FEF5C083106C4D25A91AEF0B0117E2AF9A291AA32E14AB834DC56ED2A223444547E01F11D3B0916E5A4C345CACB36'])
+     */
+    private val referenceHexString = "d28443a10126a10462313154546869732069732074686520636f6e74656e" +
+        "742e58408eb33e4ca31d1c465ab05aac34cc6b23d58fef5c083106c4d25a" +
+        "91aef0b0117e2af9a291aa32e14ab834dc56ed2a223444547e01f11d3b09" +
+        "16e5a4c345cacb36"
+
+    @Test
+    fun writeReadVerifyCoseSigned() {
+        assertEquals(reference, Cbor.decodeFromHexString(CoseSigned.serializer(), referenceHexString))
+        assertEquals(referenceHexString, Cbor.encodeToHexString(CoseSigned.serializer(), reference))
+    }
+
+
+    @Serializable
+    data class CoseHeader(
+        @SerialLabel(1)
+        @SerialName("alg")
+        val alg: Int? = null,
+        @SerialLabel(4)
+        @SerialName("kid")
+        @ByteString
+        val kid: String? = null,
+    )
+
+    @Serializable
+    @CborArray(18U)
+    data class CoseSigned(
+        @Serializable(with = ByteStringWrapperSerializer::class)
+        @ByteString
+        val protectedHeader: ByteStringWrapper<CoseHeader>,
+        val unprotectedHeader: CoseHeader? = null,
+        @ByteString
+        val payload: ByteArray,
+        @ByteString
+        val signature: ByteArray,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as CoseSigned
+
+            if (protectedHeader != other.protectedHeader) return false
+            if (unprotectedHeader != other.unprotectedHeader) return false
+            if (!payload.contentEquals(other.payload)) return false
+            return signature.contentEquals(other.signature)
+        }
+
+        override fun hashCode(): Int {
+            var result = protectedHeader.hashCode()
+            result = 31 * result + (unprotectedHeader?.hashCode() ?: 0)
+            result = 31 * result + payload.contentHashCode()
+            result = 31 * result + signature.contentHashCode()
+            return result
+        }
+
+    }
+
+    object ByteStringWrapperSerializer : KSerializer<ByteStringWrapper<CoseHeader>> {
+
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("ByteStringWrapperSerializer", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: ByteStringWrapper<CoseHeader>) {
+            val bytes = Cbor.encodeToByteArray(value.value)
+            encoder.encodeSerializableValue(ByteArraySerializer(), bytes)
+        }
+
+        override fun deserialize(decoder: Decoder): ByteStringWrapper<CoseHeader> {
+            val bytes = decoder.decodeSerializableValue(ByteArraySerializer())
+            return ByteStringWrapper(Cbor.decodeFromByteArray(bytes), bytes)
+        }
+
+    }
+
+}

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborIsoTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborIsoTest.kt
@@ -1,0 +1,49 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+class CborIsoTest {
+
+    private val reference = DataClass(
+        bytes = "foo".encodeToByteArray()
+    )
+
+    /**
+     * A1               # map(1)
+     *    65            # text(5)
+     *       6279746573 # "bytes"
+     *    43            # bytes(3)
+     *       666F6F     # "foo"
+     *
+     */
+    private val referenceHexString = "a165627974657343666f6f"
+
+    @Test
+    fun writeReadVerifyCoseSigned() {
+        val cbor = Cbor {
+            alwaysUseByteString = true
+        }
+        assertEquals(reference, cbor.decodeFromHexString(DataClass.serializer(), referenceHexString))
+        assertEquals(referenceHexString, cbor.encodeToHexString(DataClass.serializer(), reference))
+    }
+
+    @Serializable
+    data class DataClass(
+        @SerialName("bytes")
+        val bytes: ByteArray,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as DataClass
+
+            return bytes.contentEquals(other.bytes)
+        }
+
+        override fun hashCode(): Int {
+            return bytes.contentHashCode()
+        }
+    }
+}

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborPolymorphismTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborPolymorphismTest.kt
@@ -22,7 +22,7 @@ class CborPolymorphismTest {
             A.B("bbb"),
             A.serializer(),
             cbor,
-            hexResultToCheck = "9f78336b6f746c696e782e73657269616c697a6174696f6e2e63626f722e43626f72506f6c796d6f72706869736d546573742e412e42bf616263626262ffff"
+            hexResultToCheck = "9f78336b6f746c696e782e73657269616c697a6174696f6e2e63626f722e43626f72506f6c796d6f72706869736d546573742e412e42a1616263626262ff"
         )
     }
 

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
@@ -1,12 +1,15 @@
 package kotlinx.serialization.cbor
 
 import kotlinx.serialization.*
+import kotlinx.serialization.cbor.internal.*
+import kotlinx.serialization.cbor.internal.CborDecodingException
 import kotlin.test.*
 
 
 class CborSerialLabelTest {
 
     private val reference = ClassWithSerialLabel(alg = -7)
+
 
     /**
      * A1    # map(1)
@@ -42,11 +45,78 @@ class CborSerialLabelTest {
         assertEquals(reference, cbor.decodeFromHexString(ClassWithSerialLabel.serializer(), referenceHexNameString))
     }
 
+    @Test
+    fun writeReadVerifySerialLabelWithTags() {
+        val referenceWithTag = ClassWithSerialLabelAndTag(alg = -7)
+        /**
+         * A1       # map(1)
+         *    C5    # tag(5)
+         *       01 # unsigned(1)
+         *    26    # negative(6)
+         */
+        val referenceHexLabelWithTagString = "a1c50126"
+        val cbor = Cbor {
+            preferSerialLabelsOverNames = true
+            writeKeyTags = true
+            verifyKeyTags = true
+        }
+        assertEquals(referenceHexLabelWithTagString, cbor.encodeToHexString(ClassWithSerialLabelAndTag.serializer(), referenceWithTag))
+        assertEquals(referenceWithTag, cbor.decodeFromHexString(ClassWithSerialLabelAndTag.serializer(), referenceHexLabelWithTagString))
+    }
+
+    @Test
+    fun writeReadVerifySerialLabelWithTagsThrowing() {
+        /**
+         * A1       # map(1)
+         *    C6    # tag(6)        // wrong tag: declared is 5U, meaning C5 in hex
+         *       01 # unsigned(1)
+         *    26    # negative(6)
+         */
+        val referenceHexLabelWithTagString = "a1c60126"
+        val cbor = Cbor {
+            preferSerialLabelsOverNames = true
+            writeKeyTags = true
+            verifyKeyTags = true
+        }
+        assertFailsWith(CborDecodingException::class) {
+            cbor.decodeFromHexString(ClassWithSerialLabelAndTag.serializer(), referenceHexLabelWithTagString)
+        }
+    }
+
+    @Test
+    fun writeReadVerifySerialLabelWithTagsAndUnknownKeys() {
+        val referenceWithTag = ClassWithSerialLabelAndTag(alg = -7)
+        /**
+         * A2           # map(2)
+         *    C5        # tag(5)
+         *       01     # unsigned(1)
+         *    26        # negative(6)
+         *    02        # unsigned(2)
+         *    63        # text(3)
+         *       62617A # "baz"
+         */
+        val referenceHexLabelWithTagString = "a2c50126026362617a"
+        val cbor = Cbor {
+            preferSerialLabelsOverNames = true
+            writeKeyTags = true
+            verifyKeyTags = true
+            ignoreUnknownKeys = true
+        }
+        assertEquals(referenceWithTag, cbor.decodeFromHexString(ClassWithSerialLabelAndTag.serializer(), referenceHexLabelWithTagString))
+    }
 
     @Serializable
     data class ClassWithSerialLabel(
         @SerialLabel(1)
         @SerialName("alg")
+        val alg: Int
+    )
+
+    @Serializable
+    data class ClassWithSerialLabelAndTag(
+        @SerialLabel(1)
+        @SerialName("alg")
+        @KeyTags(5U)
         val alg: Int
     )
 

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
@@ -9,19 +9,21 @@ class CborSerialLabelTest {
     private val reference = ClassWithSerialLabel(alg = -7)
 
     /**
-     * A1    # map(1)
+     * BF    # map(*)
      *    01 # unsigned(1)
      *    26 # negative(6)
+     *    FF # primitive(*)
      */
-    private val referenceHexLabelString = "a10126"
+    private val referenceHexLabelString = "bf0126ff"
 
     /**
-     * A1           # map(1)
+     * BF           # map(*)
      *    63        # text(3)
      *       616C67 # "alg"
      *    26        # negative(6)
+     *    FF        # primitive(*)
      */
-    private val referenceHexNameString = "a163616c6726"
+    private val referenceHexNameString = "bf63616c6726ff"
 
 
     @Test

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
@@ -3,32 +3,52 @@ package kotlinx.serialization.cbor
 import kotlinx.serialization.*
 import kotlin.test.*
 
-@Serializable
-data class CoseHeader(
-    @SerialLabel(4)
-    @SerialName("kid")
-    val kid: String? = null,
-)
 
 class CborSerialLabelTest {
 
-    private val reference = CoseHeader(
-        kid = "11"
-    )
+    private val reference = ClassWithSerialLabel(alg = -7)
 
-    /*
-        BF         # map(*)
-           04      # unsigned(4)
-           62      # text(2)
-              3131 # "11"
-           FF      # primitive(*)
+    /**
+     * A1    # map(1)
+     *    01 # unsigned(1)
+     *    26 # negative(6)
      */
-    private val referenceHexString = "bf04623131ff"
+    private val referenceHexLabelString = "a10126"
+
+    /**
+     * A1           # map(1)
+     *    63        # text(3)
+     *       616C67 # "alg"
+     *    26        # negative(6)
+     */
+    private val referenceHexNameString = "a163616c6726"
 
 
     @Test
-    fun writeReadVerifyCoseHeader() {
-        assertEquals(referenceHexString, Cbor.encodeToHexString(CoseHeader.serializer(), reference))
-        assertEquals(reference, Cbor.decodeFromHexString(CoseHeader.serializer(), referenceHexString))
+    fun writeReadVerifySerialLabel() {
+        val cbor = Cbor {
+            preferSerialLabelsOverNames = true
+        }
+        assertEquals(referenceHexLabelString, cbor.encodeToHexString(ClassWithSerialLabel.serializer(), reference))
+        assertEquals(reference, cbor.decodeFromHexString(ClassWithSerialLabel.serializer(), referenceHexLabelString))
     }
+
+    @Test
+    fun writeReadVerifySerialName() {
+        val cbor = Cbor {
+            preferSerialLabelsOverNames = false
+        }
+        assertEquals(referenceHexNameString, cbor.encodeToHexString(ClassWithSerialLabel.serializer(), reference))
+        assertEquals(reference, cbor.decodeFromHexString(ClassWithSerialLabel.serializer(), referenceHexNameString))
+    }
+
+
+    @Serializable
+    data class ClassWithSerialLabel(
+        @SerialLabel(1)
+        @SerialName("alg")
+        val alg: Int
+    )
+
 }
+

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
@@ -1,0 +1,34 @@
+package kotlinx.serialization.cbor
+
+import kotlinx.serialization.*
+import kotlin.test.*
+
+@Serializable
+data class CoseHeader(
+    @SerialLabel(4)
+    @SerialName("kid")
+    val kid: String? = null,
+)
+
+class CborSerialLabelTest {
+
+    private val reference = CoseHeader(
+        kid = "11"
+    )
+
+    /*
+        BF         # map(*)
+           04      # unsigned(4)
+           62      # text(2)
+              3131 # "11"
+           FF      # primitive(*)
+     */
+    private val referenceHexString = "bf04623131ff"
+
+
+    @Test
+    fun writeReadVerifyCoseHeader() {
+        assertEquals(referenceHexString, Cbor.encodeToHexString(CoseHeader.serializer(), reference))
+        assertEquals(reference, Cbor.decodeFromHexString(CoseHeader.serializer(), referenceHexString))
+    }
+}

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborSerialLabelTest.kt
@@ -9,21 +9,19 @@ class CborSerialLabelTest {
     private val reference = ClassWithSerialLabel(alg = -7)
 
     /**
-     * BF    # map(*)
+     * A1    # map(1)
      *    01 # unsigned(1)
      *    26 # negative(6)
-     *    FF # primitive(*)
      */
-    private val referenceHexLabelString = "bf0126ff"
+    private val referenceHexLabelString = "a10126"
 
     /**
-     * BF           # map(*)
+     * A1           # map(1)
      *    63        # text(3)
      *       616C67 # "alg"
      *    26        # negative(6)
-     *    FF        # primitive(*)
      */
-    private val referenceHexNameString = "bf63616c6726ff"
+    private val referenceHexNameString = "a163616c6726"
 
 
     @Test

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborTaggedTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborTaggedTest.kt
@@ -54,8 +54,8 @@ class CborTaggedTest {
         d = "Hello World"
     )
 
-    /*
-     * BF                                 # map(*)
+    /**
+     * A4                                 # map(4)
      *    61                              # text(1)
      *       61                           # "a"
      *    CC                              # tag(12)
@@ -76,13 +76,12 @@ class CborTaggedTest {
      *       CC                           # tag(12)
      *          6B                        # text(11)
      *             48656C6C6F20576F726C64 # "Hello World"
-     *    FF                              # primitive(*)
      */
     private val referenceHexString =
-        "bf6161cc1a0fffffffd822616220d8386163d84e42cafe6164d85acc6b48656c6c6f20576f726c64ff"
+        "a46161cc1a0fffffffd822616220d8386163d84e42cafe6164d85acc6b48656c6c6f20576f726c64"
 
-    /*
-     * BF                                 # map(*)
+    /**
+     * A4                                 # map(4)
      *    61                              # text(1)
      *       61                           # "a"
      *    CC                              # tag(12)
@@ -101,12 +100,11 @@ class CborTaggedTest {
      *       CC                           # tag(12)
      *          6B                        # text(11)
      *             48656C6C6F20576F726C64 # "Hello World"
-     *    FF                              # primitive(*)
      */
-    private val noKeyTags = "bf6161cc1a0fffffff6162206163d84e42cafe6164d85acc6b48656c6c6f20576f726c64ff"
+    private val noKeyTags = "a46161cc1a0fffffff6162206163d84e42cafe6164d85acc6b48656c6c6f20576f726c64"
 
-    /*
-     * BF                           # map(*)
+    /**
+     * A4                           # map(4)
      *    61                        # text(1)
      *       61                     # "a"
      *    1A 0FFFFFFF               # unsigned(268435455)
@@ -123,12 +121,11 @@ class CborTaggedTest {
      *       64                     # "d"
      *    6B                        # text(11)
      *       48656C6C6F20576F726C64 # "Hello World"
-     *    FF                        # primitive(*)
      */
-    private val noValueTags = "bf61611a0fffffffd822616220d838616342cafe61646b48656c6c6f20576f726c64ff"
+    private val noValueTags = "a461611a0fffffffd822616220d838616342cafe61646b48656c6c6f20576f726c64"
 
-    /*
-     * BF                           # map(*)
+    /**
+     * A4                           # map(4)
      *    61                        # text(1)
      *       61                     # "a"
      *    1A 0FFFFFFF               # unsigned(268435455)
@@ -143,10 +140,8 @@ class CborTaggedTest {
      *       64                     # "d"
      *    6B                        # text(11)
      *       48656C6C6F20576F726C64 # "Hello World"
-     *    FF                        # primitive(*)
-     *
      */
-    private val noTags = "bf61611a0fffffff616220616342cafe61646b48656c6c6f20576f726c64ff"
+    private val noTags = "a461611a0fffffff616220616342cafe61646b48656c6c6f20576f726c64"
 
     @Test
     fun writeReadVerifyTaggedClass() {

--- a/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborWriterTest.kt
+++ b/formats/cbor/commonTest/src/kotlinx/serialization/cbor/CborWriterTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.*
 class CbrWriterTest {
     @Test
     fun writeSimpleClass() {
-        assertEquals("bf616163737472ff", Cbor.encodeToHexString(Simple.serializer(), Simple("str")))
+        assertEquals("a1616163737472", Cbor.encodeToHexString(Simple.serializer(), Simple("str")))
     }
 
     @Test
@@ -27,8 +27,63 @@ class CbrWriterTest {
             HexConverter.parseHexBinary("cafe"),
             HexConverter.parseHexBinary("cafe")
         )
+        /**
+         * A9                               # map(9)
+         *    63                            # text(3)
+         *       737472                     # "str"
+         *    6D                            # text(13)
+         *       48656C6C6F2C20776F726C6421 # "Hello, world!"
+         *    61                            # text(1)
+         *       69                         # "i"
+         *    18 2A                         # unsigned(42)
+         *    68                            # text(8)
+         *       6E756C6C61626C65           # "nullable"
+         *    F6                            # primitive(22)
+         *    64                            # text(4)
+         *       6C697374                   # "list"
+         *    9F                            # array(*)
+         *       61                         # text(1)
+         *          61                      # "a"
+         *       61                         # text(1)
+         *          62                      # "b"
+         *       FF                         # primitive(*)
+         *    63                            # text(3)
+         *       6D6170                     # "map"
+         *    BF                            # map(*)
+         *       01                         # unsigned(1)
+         *       F5                         # primitive(21)
+         *       02                         # unsigned(2)
+         *       F4                         # primitive(20)
+         *       FF                         # primitive(*)
+         *    65                            # text(5)
+         *       696E6E6572                 # "inner"
+         *    A1                            # map(1)
+         *       61                         # text(1)
+         *          61                      # "a"
+         *       63                         # text(3)
+         *          6C6F6C                  # "lol"
+         *    6A                            # text(10)
+         *       696E6E6572734C697374       # "innersList"
+         *    9F                            # array(*)
+         *       A1                         # map(1)
+         *          61                      # text(1)
+         *             61                   # "a"
+         *          63                      # text(3)
+         *             6B656B               # "kek"
+         *       FF                         # primitive(*)
+         *    6A                            # text(10)
+         *       62797465537472696E67       # "byteString"
+         *    42                            # bytes(2)
+         *       CAFE                       # "\xCA\xFE"
+         *    69                            # text(9)
+         *       627974654172726179         # "byteArray"
+         *    9F                            # array(*)
+         *       38 35                      # negative(53)
+         *       21                         # negative(1)
+         *       FF                         # primitive(*)
+         */
         assertEquals(
-            "bf637374726d48656c6c6f2c20776f726c64216169182a686e756c6c61626c65f6646c6973749f61616162ff636d6170bf01f502f4ff65696e6e6572bf6161636c6f6cff6a696e6e6572734c6973749fbf6161636b656bffff6a62797465537472696e6742cafe696279746541727261799f383521ffff",
+            "a9637374726d48656c6c6f2c20776f726c64216169182a686e756c6c61626c65f6646c6973749f61616162ff636d6170bf01f502f4ff65696e6e6572a16161636c6f6c6a696e6e6572734c6973749fa16161636b656bff6a62797465537472696e6742cafe696279746541727261799f383521ff",
             Cbor.encodeToHexString(TypesUmbrella.serializer(), test)
         )
     }
@@ -43,38 +98,59 @@ class CbrWriterTest {
             true,
             'a'
         )
+        /**
+         * A6                     # map(6)
+         *    63                  # text(3)
+         *       696E74           # "int"
+         *    1A 00018894         # unsigned(100500)
+         *    64                  # text(4)
+         *       6C6F6E67         # "long"
+         *    1B 7FFFFFFFFFFFFFFF # unsigned(9223372036854775807)
+         *    65                  # text(5)
+         *       666C6F6174       # "float"
+         *    FA 42280000         # primitive(1109917696)
+         *    66                  # text(6)
+         *       646F75626C65     # "double"
+         *    FB 4271FB0C5A2B7000 # primitive(4787883909342523392)
+         *    67                  # text(7)
+         *       626F6F6C65616E   # "boolean"
+         *    F5                  # primitive(21)
+         *    64                  # text(4)
+         *       63686172         # "char"
+         *    18 61               # unsigned(97)
+         */
         assertEquals(
-            "bf63696e741a00018894646c6f6e671b7fffffffffffffff65666c6f6174fa4228000066646f75626c65fb4271fb0c5a2b700067626f6f6c65616ef564636861721861ff",
+            "a663696e741a00018894646c6f6e671b7fffffffffffffff65666c6f6174fa4228000066646f75626c65fb4271fb0c5a2b700067626f6f6c65616ef564636861721861",
             Cbor.encodeToHexString(NumberTypesUmbrella.serializer(), test)
         )
     }
 
     @Test
     fun testWriteByteStringWhenNullable() {
-        /* BF                         # map(*)
+        /**
+         * A1                         # map(1)
          *    6A                      # text(10)
          *       62797465537472696E67 # "byteString"
          *    44                      # bytes(4)
-         *       01020304             # "\x01\x02\x03\x04"
-         *    FF                      # primitive(*)
+         *       01020304             # "\u0001\u0002\u0003\u0004"
          */
         assertEquals(
-            expected = "bf6a62797465537472696e674401020304ff",
+            expected = "a16a62797465537472696e674401020304",
             actual = Cbor.encodeToHexString(
                 serializer = NullableByteString.serializer(),
                 value = NullableByteString(byteString = byteArrayOf(1, 2, 3, 4))
             )
         )
 
-        /* BF                         # map(*)
+        /**
+         * A1                         # map(1)
          *    6A                      # text(10)
          *       62797465537472696E67 # "byteString"
          *    40                      # bytes(0)
          *                            # ""
-         *    FF                      # primitive(*)
          */
         assertEquals(
-            expected = "bf6a62797465537472696e6740ff",
+            expected = "a16a62797465537472696e6740",
             actual = Cbor.encodeToHexString(
                 serializer = NullableByteString.serializer(),
                 value = NullableByteString(byteString = byteArrayOf())
@@ -84,14 +160,14 @@ class CbrWriterTest {
 
     @Test
     fun testWriteNullForNullableByteString() {
-        /* BF                         # map(*)
+        /**
+         * A1                         # map(1)
          *    6A                      # text(10)
          *       62797465537472696E67 # "byteString"
          *    F6                      # primitive(22)
-         *    FF                      # primitive(*)
          */
         assertEquals(
-            expected = "bf6a62797465537472696e67f6ff",
+            expected = "a16a62797465537472696e67f6",
             actual = Cbor.encodeToHexString(
                 serializer = NullableByteString.serializer(),
                 value = NullableByteString(byteString = null)
@@ -101,24 +177,44 @@ class CbrWriterTest {
 
     @Test
     fun testWriteCustomByteString() {
+        /**
+         * A1           # map(1)
+         *    61        # text(1)
+         *       78     # "x"
+         *    43        # bytes(3)
+         *       112233 # "\u0011\"3"
+         */
         assertEquals(
-            expected = "bf617843112233ff",
+            expected = "a1617843112233",
             actual = Cbor.encodeToHexString(TypeWithCustomByteString(CustomByteString(0x11, 0x22, 0x33)))
         )
     }
 
     @Test
     fun testWriteNullableCustomByteString() {
+        /**
+         * A1           # map(1)
+         *    61        # text(1)
+         *       78     # "x"
+         *    43        # bytes(3)
+         *       112233 # "\u0011\"3"
+         */
         assertEquals(
-            expected = "bf617843112233ff",
+            expected = "a1617843112233",
             actual = Cbor.encodeToHexString(TypeWithNullableCustomByteString(CustomByteString(0x11, 0x22, 0x33)))
         )
     }
 
     @Test
     fun testWriteNullCustomByteString() {
+        /**
+         * A1       # map(1)
+         *    61    # text(1)
+         *       78 # "x"
+         *    F6    # primitive(22)
+         */
         assertEquals(
-            expected = "bf6178f6ff",
+            expected = "a16178f6",
             actual = Cbor.encodeToHexString(TypeWithNullableCustomByteString(null))
         )
     }


### PR DESCRIPTION
If we would want to support multiplatform serialization of COSE structures, we would need the following features in CBOR serialization:

- Write/read numbers as map keys instead of strings
- Support wrapping complex objects into byte strings before serialization
- Support serializing a class as a CBOR aray

This is an internal MR to prepare the branch for a public pull request against kotlinx.serialization.

Please note that serializing classes as maps with definite length does only work with non-nullable members and should thus be either fixed before submitting an upstream pull request or omitted ...